### PR TITLE
Remove stamina

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "httpx",
     "aioboto3",
     "types-aioboto3[s3]",
-    "stamina",
     "pydantic",
     "pyvips",
     "pyvips-binary",

--- a/safe_s3_storage/kaspersky_scan_engine.py
+++ b/safe_s3_storage/kaspersky_scan_engine.py
@@ -6,7 +6,6 @@ import typing
 
 import httpx
 import pydantic
-import stamina
 
 from safe_s3_storage.exceptions import KasperskyScanEngineConnectionStatusError, KasperskyScanEngineThreatDetectedError
 
@@ -53,9 +52,7 @@ class KasperskyScanEngineClient:
             timeout=str(self.timeout_ms), object=base64.b64encode(file_content).decode(), name=self.client_name
         ).model_dump(mode="json")
         try:
-            response: typing.Final = await stamina.retry(on=httpx.HTTPError, attempts=self.max_retries)(
-                self._send_scan_memory_request
-            )(payload)
+            response: typing.Final = await self._send_scan_memory_request(payload)
         except httpx.HTTPStatusError as exc:
             raise KasperskyScanEngineConnectionStatusError from exc
         validated_response: typing.Final = KasperskyScanEngineResponse.model_validate_json(response)

--- a/safe_s3_storage/kaspersky_scan_engine.py
+++ b/safe_s3_storage/kaspersky_scan_engine.py
@@ -1,17 +1,12 @@
 import base64
 import dataclasses
 import enum
-import logging
 import typing
 
 import httpx
 import pydantic
 
 from safe_s3_storage.exceptions import KasperskyScanEngineConnectionStatusError, KasperskyScanEngineThreatDetectedError
-
-
-kaspersky_logger: typing.Final = logging.getLogger(__name__)
-kaspersky_logger.setLevel(logging.ERROR)
 
 
 class KasperskyScanEngineRequest(pydantic.BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,11 @@ import typing
 
 import faker
 import pytest
-import stamina
 
 
 @pytest.fixture(scope="session", autouse=True)
 def anyio_backend() -> str:
     return "asyncio"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def deactivate_retries() -> None:
-    stamina.set_active(False)
 
 
 MIME_OCTET_STREAM: typing.Final = "application/octet-stream"


### PR DESCRIPTION
If you, guys, don't mind, I came to conclusion to remove retries from this library completely. Because we have very verbose error, that can be catched in main srcs. And each team prefer their own solutions towards retrues. Eg we are using tenacity. But now I see reasons to avoid introductions of retriers. Lets pass it to users.

P.s. previous solution to prevent  logs from printing whole file was to no avail. We have to either add another retrier here, or think about it in main srscs. I think the second one is better