### PR TITLE
Change puremagic to python-magic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pydantic",
     "pyvips",
     "pyvips-binary",
-    "python-magic",
+    "magika",
 ]
 
 [dependency-groups]

--- a/safe_s3_storage/file_validator.py
+++ b/safe_s3_storage/file_validator.py
@@ -2,8 +2,8 @@ import dataclasses
 import enum
 import typing
 
-import magic
 import pyvips  # type: ignore[import-untyped]
+from magika import Magika
 
 from safe_s3_storage import exceptions
 from safe_s3_storage.kaspersky_scan_engine import KasperskyScanEngineClient
@@ -48,7 +48,8 @@ class FileValidator:
     image_quality: int = 85
 
     def _validate_mime_type(self, *, file_name: str, file_content: bytes) -> str:
-        mime_type: typing.Final = magic.from_buffer(file_content, mime=True)
+        mime_type_prediction: typing.Final = Magika().identify_bytes(file_content)
+        mime_type: typing.Final = mime_type_prediction.prediction.dl.mime_type
         if self.allowed_mime_types is None or mime_type in self.allowed_mime_types:
             return mime_type
 


### PR DESCRIPTION
Weeell, we have some problems. Puremagic is okay, until you start checking Microsoft extensions. I dunno, maybe the developer has some beef with MS or smth like this. As an example for .xls files, puremagic.from_string(file) returns ''. pure.magic_file(file) returns different mime_type, that we got used to. So, either we have to change mime_types and method to magic_file. Or swap completely towards python-magic. I prefer the second one. If you don't mind, let's stick with it