### PR TITLE
fix: disable libvips operation cache to stop image-conversion memory leak

### DIFF
--- a/safe_s3_storage/file_validator.py
+++ b/safe_s3_storage/file_validator.py
@@ -75,6 +75,13 @@ class FileValidator:
     def _convert_image(self, validated_file: ValidatedFile) -> ValidatedFile:
         import pyvips  # type: ignore[import-untyped] # noqa: PLC0415
 
+        # libvips keeps a process-global operation cache. For one-shot conversions of
+        # unique upload buffers it never hits and only retains memory, so disable it.
+        # The guard makes the setter effectively run once (max is 0 after the first
+        # call) and avoids a module-level global that ruff's ALL ruleset would flag.
+        if pyvips.cache_get_max():
+            pyvips.cache_set_max(0)
+
         if not _is_image(validated_file.mime_type):
             return validated_file
 

--- a/tests/test_file_validator.py
+++ b/tests/test_file_validator.py
@@ -4,6 +4,7 @@ import typing
 import faker
 import httpx
 import pytest
+import pyvips  # type: ignore[import-untyped]
 from httpx import codes as status_codes
 
 from safe_s3_storage import exceptions
@@ -212,3 +213,15 @@ class TestFileValidator:
         assert validated_file.file_name == f"{file_base_name}.{file_extension}"
         assert validated_file.file_content == png_file
         assert validated_file.file_size == len(validated_file.file_content)
+
+    async def test_conversion_does_not_leave_pyvips_operations_cached(
+        self, faker: faker.Faker, png_file: bytes
+    ) -> None:
+        # libvips keeps a process-global operation cache; for one-shot conversions of
+        # unique buffers it only retains memory. The validator must disable it so the
+        # cache does not accumulate across conversions (memory leak).
+        await FileValidator(allowed_mime_types=["image/png"]).validate_file(
+            file_name=f"{faker.pystr()}.png", file_content=png_file
+        )
+
+        assert pyvips.cache_get_size() == 0


### PR DESCRIPTION
## Problem

Long-running services that convert many uploads (e.g. an upload/S3 gateway) show steady process memory growth correlated with traffic that looks like a leak.

## Root cause

`FileValidator._convert_image` converts every image with libvips via `pyvips.Image.new_from_buffer(...).write_to_buffer(...)`. libvips keeps a **process-global operation cache** enabled by default (up to ~1000 operations, plus memory/file caps). Each cached operation pins references to its image buffers, so across conversions memory climbs until the caps are hit. Every upload is a unique buffer, so the cache never produces a hit: it is pure retained memory with no benefit for this workload.

This is the standard libvips-in-a-server behavior; pyvips' own `examples/soak-test.py` prevents it with `pyvips.cache_set_max(0)`.

### Measured (pyvips 3.1.1 / libvips 8.17.3)

Running the exact conversion in a loop and reading `pyvips.cache_get_size()`:

- start: 0
- after 5 default conversions: 35 (one `new_from_buffer` decomposes into several cached ops, each pinning buffers)
- after `cache_set_max(0)`: stays 0

## Fix

Disable the libvips operation cache on the conversion path with `pyvips.cache_set_max(0)`, guarded by a `pyvips.cache_get_max()` check so the setter effectively runs once. The `import pyvips` stays local to `_convert_image`. No public API change; conversion output, formats, quality, and error handling are unchanged.

## Test

Added a TDD regression test asserting `pyvips.cache_get_size() == 0` after a conversion. It only observes cache size (never mutates it), so it is order-independent: red on `main` (nonzero), green with the fix. Full suite: 36 passing, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
